### PR TITLE
Fix when a factory for a ws WebSocket is used

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "websocket-as-promised",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "A WebSocket client library providing Promise-based API for connecting, disconnecting and messaging with server",
   "author": {
     "name": "Vitaliy Potapov",

--- a/src/index.js
+++ b/src/index.js
@@ -314,7 +314,7 @@ class WebSocketAsPromised {
   }
 
   _handleMessage(event) {
-    const message = event.data;
+    const message = event.data || event;
     this._onMessage.dispatchAsync(message);
     this._handleUnpackedMessage(message);
   }


### PR DESCRIPTION
We are using:
```ts
import WebSocket from "isomorphic-ws";
```
In both node and in the browser. When we supplied our own WebSocket factory:
```ts
 this.socket = new WebSocketAsPromised(this.endpoint, {
      packMessage: (data: any) => JSON.stringify(data),
      unpackMessage: (message: string) => JSON.parse(message),
      attachRequestId: (data: any, requestId: number) => Object.assign({ id: requestId }, data),
      extractRequestId: (data: any) => data && data.id,
      createWebSocket: (url: string) => new WebSocket(url),
    } as any);
```

The messages were undefined. This change fixes.

Great library. Thanks!