### PR TITLE
add support for unexpected-response

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -338,6 +338,7 @@ class WebSocketAsPromised {
       { channel: this._ws, event: 'message', listener: e => this._handleMessage(e) },
       { channel: this._ws, event: 'error', listener: e => this._handleError(e) },
       { channel: this._ws, event: 'close', listener: e => this._handleClose(e) },
+      { channel: this._ws, event: 'unexpected-response', listener: (_, res) => this._handleClose({ reason: res.statusMessage, code: res.statusCode }) },
     ]).on();
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -406,6 +406,8 @@ class WebSocketAsPromised {
     this._onClose.dispatchAsync(event);
     this._closing.resolve(event);
     const error = new Error(`WebSocket closed with reason: ${event.reason} (${event.code}).`);
+    error.reason = event.reason;
+    error.code = event.code;
     if (this._opening.isPending) {
       this._opening.reject(error);
     }


### PR DESCRIPTION
I'm almost certain this isn't the right way to handle this but it works.

Without this when my server disconnects my client the client doesn't have any way of reacting to the statusCode and/or reason.