### PR TITLE
Introducing a "notification" concept

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,11 @@ By default `requestId` value is auto-generated, but you can set it manually:
 wsp.sendRequest({foo: 'bar'}, {requestId: 42});
 ```
 
+When use send/request pattern, you can listen a notification which the message does not contain a `id` property.
+```js
+wsp.onUnpackedNotif.addListener(data => console.log(JSON.stringify(data)));
+```
+
 > Note: you should implement yourself attaching `requestId` on server side.
 
 ## API
@@ -213,6 +218,7 @@ wsp.sendRequest({foo: 'bar'}, {requestId: 42});
     * [.onSend](#WebSocketAsPromised+onSend) ⇒ <code>Channel</code>
     * [.onMessage](#WebSocketAsPromised+onMessage) ⇒ <code>Channel</code>
     * [.onUnpackedMessage](#WebSocketAsPromised+onUnpackedMessage) ⇒ <code>Channel</code>
+    * [.onUnpackedNotif](#WebSocketAsPromised+onUnpackedNotif) ⇒ <code>Channel</code>
     * [.onResponse](#WebSocketAsPromised+onResponse) ⇒ <code>Channel</code>
     * [.onClose](#WebSocketAsPromised+onClose) ⇒ <code>Channel</code>
     * [.onError](#WebSocketAsPromised+onError) ⇒ <code>Channel</code>
@@ -316,6 +322,18 @@ For example, if you are using JSON transport, the listener will receive already 
 **Example**  
 ```js
 wsp.onUnpackedMessage.addListener(data => console.log(data.foo));
+```
+<a name="WebSocketAsPromised+onUnpackedNotif"></a>
+
+#### wsp.onUnpackedNotif ⇒ <code>Channel</code>
+Event channel triggered every time when a notification which does not contain an `id` property is successfully unpacked. 
+For example, if you are using JSON transport, the listener will receive already JSON parsed data.
+
+**Kind**: instance property of [<code>WebSocketAsPromised</code>](#WebSocketAsPromised)  
+**See**: https://vitalets.github.io/chnl/#channel  
+**Example**
+```js
+wsp.onUnpackedNotif.addListener(data => console.log(data.foo));
 ```
 <a name="WebSocketAsPromised+onResponse"></a>
 

--- a/browerify-standalone.bat
+++ b/browerify-standalone.bat
@@ -1,0 +1,1 @@
+browserify src/index.js --standalone WebSocketAsPromised -o dist/websocket-as-promised-2.0.1.js


### PR DESCRIPTION
Introducing a "notification" concept. Request/response messages both have an id attribute, while notification messages are messages that do not contain an id attribute and can be used for server-initiated notification messages. Changes include:

- WebSocketAsPromised adds an onUnpackedNotif event handler.

- The original _tryHandleResponse method is modified to return a boolean value to reflect whether the given data parameter contains an id attribute.

- Addition of a browserify script.

- Minor usage instructions added to README.md.