### PR TITLE
fix: fixed missing `event.reason` (fallback to `event.message`)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -404,7 +404,7 @@ class WebSocketAsPromised {
   _handleClose(event) {
     this._onClose.dispatchAsync(event);
     this._closing.resolve(event);
-    const error = new Error(`WebSocket closed with reason: ${event.reason} (${event.code}).`);
+    const error = new Error(`WebSocket closed with reason: ${event.reason || event.message} (${event.code}).`);
     if (this._opening.isPending) {
       this._opening.reject(error);
     }


### PR DESCRIPTION
In some cases (e.g. abnormal exit code 1006) the `event.reason` is not populated (e.g. using `ws` library).  This commit ensures that the reason is always present in the message.